### PR TITLE
Updating README: rename menuBtn to btn to match options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jEmoji will create emoji menu and it will start detection when user type ':' (co
 Using [Bootstrap input groups](http://getbootstrap.com/components/#input-groups) we allow our users to open emoji menu on click an specific button.
 
     $('#example').jemoji({
-      menuBtn:    $('#show-menu'),
+      btn:    $('#show-menu'),
       container:  $('#example').parent().parent()
     });
 


### PR DESCRIPTION
This was drove me crazy a little bit, and took me longer than id like to admit to root-cause 😏 

Another heads-up, the documentation here is also out of sync.
http://franverona.com/jemoji/#documentation

Though, perhaps you wanted `options.btn` to become `options.menuBtn`???

Great addon, btw. Easy to use, right out of the box!