### PR TITLE
Fix for disappearing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jEmoji will create emoji menu and it will start detection when user type ':' (co
 Using [Bootstrap input groups](http://getbootstrap.com/components/#input-groups) we allow our users to open emoji menu on click an specific button.
 
     $('#example').jemoji({
-      menuBtn:    $('#show-menu'),
+      btn:        $('#show-menu'),
       container:  $('#example').parent().parent()
     });
 

--- a/jemoji.js
+++ b/jemoji.js
@@ -197,7 +197,7 @@ if (typeof(jQuery) === 'undefined') {
     $el.data('jemojiclick', function () {
       $(d).find('div').off('click').on('click', function () {
         var emojiCode = $(this).find('img').attr('alt'), cursor = getCursorPosition(), value = $el.val();
-        value = value.slice(0, value.lastIndexOf(':', cursor)) + ':' + emojiCode + ': ' + value.slice(cursor);
+        value = value.slice(0, cursor) + ':' + emojiCode + ': ' + value.slice(cursor);
         $el.val(value);
         $el.focus();
         menuOpened = false;


### PR DESCRIPTION
When inserting an emoji by clicking on it, text between the cursor position and the last ':' disappears. To test it, you can enter for example:
`:100: Test`
Now, if you open the menu and click some emoji, let's say `:+1:`, the text will now be `:100:+1:`.

This PR fixes that, and corrects a little mistake in the readme.